### PR TITLE
Associate with .x files used by Rust embedded

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
                 "extensions": [
                     ".ld",
                     ".dld",
-                    ".lds"
+                    ".lds",
+                    ".x"
                 ],
                 "configuration": "./config/language-configuration.json"
             }


### PR DESCRIPTION
Thanks for a great extension!

I added .x files in the list used by the toolchain for embedded Rust code. 
The format is the same as gnu linker scripts.